### PR TITLE
fix: can't override data when mockContext(data)

### DIFF
--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -146,7 +146,7 @@ module.exports = {
    * @return {Request} req
    */
   mockRequest(req) {
-    req = req || {};
+    req = Object.assign({}, req);
     const headers = req.headers || {};
     for (const key in req.headers) {
       headers[key.toLowerCase()] = req.headers[key];

--- a/test/ctx.test.js
+++ b/test/ctx.test.js
@@ -40,4 +40,12 @@ describe('test/ctx.test.js', () => {
     assert(data === 'bar');
   });
 
+  it('should not override mockData', function* () {
+    const mockData = { user: 'popomore' };
+    app.mockContext(mockData);
+    app.mockContext(mockData);
+    assert(!mockData.headers);
+    assert(!mockData.method);
+  });
+
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

mm.app

##### Description of change
<!-- Provide a description of the change below this comment. -->

can't override data when mockContext(data), if I call mockContext twice, data has changed.