### PR TITLE
refactor: use mockHttpclient instead of mockUrllib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '4'
   - '6'
+  - '7'
 install:
   - npm i npminstall && npminstall
 script:

--- a/README.md
+++ b/README.md
@@ -331,25 +331,25 @@ request(app.callback())
 .expect(302, done);
 ```
 
-### app.mockUrllib(url, method, data)
+### app.mockHttpclient(url, method, data)
 
-Mock `ctx.curl`
+Mock httpclient request, e.g.: `ctx.curl`
 
 ```js
 app.get('/', function*() {
-  const ret = yield this.curl('https://eggjs.org ');
+  const ret = yield this.curl('https://eggjs.org');
   this.body = ret.data.toString();
 });
 
-app.mockUrllib('https://eggjs.org ', {
-  // 模拟的参数，可以是 buffer / string / json，
-  // 都会转换成 buffer
-  // 按照请求时的 options.dataType 来做对应的转换
+app.mockHttpclient('https://eggjs.org', {
+  // can be buffer / string / json，
+  // will auto convert to buffer
+  // follow options.dataType to convert
   data: 'mock taobao',
 });
 request(app.callback())
-.post('/')
-.expect('mock taobao', done);
+  .post('/')
+  .expect('mock taobao', done);
 ```
 
 ## Questions & Suggestions

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -345,25 +345,25 @@ request(app.callback())
 .expect(302, done);
 ```
 
-### app.mockUrllib(url, method, data)
+### app.mockHttpclient(url, method, data)
 
-模拟 curl
+模拟 httpclient 的请求，例如 `ctx.curl`
 
 ```js
 app.get('/', function*() {
-  const ret = yield this.curl('https://eggjs.org ');
+  const ret = yield this.curl('https://eggjs.org');
   this.body = ret.data.toString();
 });
 
-app.mockUrllib('https://eggjs.org ', {
+app.mockHttpclient('https://eggjs.org', {
   // 模拟的参数，可以是 buffer / string / json，
   // 都会转换成 buffer
   // 按照请求时的 options.dataType 来做对应的转换
   data: 'mock taobao',
 });
 request(app.callback())
-.post('/')
-.expect('mock taobao', done);
+  .post('/')
+  .expect('mock taobao', done);
 ```
 
 ## Questions & Suggestions

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -229,8 +229,8 @@ module.exports = {
   },
 
   /**
-   * mock urllib
-   * @method App#mockUrllib
+   * mock httpclient
+   * @method App#mockHttpclient
    * @param {String} mockUrl - url
    * @param {String} mockMethod - http method
    * @param {Object} mockResult - you data
@@ -239,9 +239,9 @@ module.exports = {
    *   - headers - response header
    * @return {Context} this
    */
-  mockUrllib(mockUrl, mockMethod, mockResult) {
+  mockHttpclient(mockUrl, mockMethod, mockResult) {
     if (!mockResult) {
-      // app.mockUrllib(mockUrl, mockResult)
+      // app.mockHttpclient(mockUrl, mockResult)
       mockResult = mockMethod;
       mockMethod = 'GET';
     }
@@ -275,12 +275,12 @@ module.exports = {
     }
     mockResult.headers = mockResult.headers || {};
 
-    const urllib = this.urllib;
-    const requestThunk = urllib.requestThunk;
+    const httpclient = this.httpclient;
+    const rawRequest = httpclient.request;
 
-    mm(urllib, 'requestThunk', _request);
-    mm(urllib, 'request', _request);
-    mm(urllib, 'curl', _request);
+    mm(httpclient, 'requestThunk', _request);
+    mm(httpclient, 'request', _request);
+    mm(httpclient, 'curl', _request);
 
     return this;
 
@@ -299,7 +299,7 @@ module.exports = {
           keepAliveSocket: mockResult.keepAliveSocket || false,
         };
 
-        urllib.emit('response', {
+        httpclient.emit('response', {
           error: null,
           ctx: opt.ctx,
           req: {
@@ -321,8 +321,13 @@ module.exports = {
         }
         return mockResult;
       }
-      return yield requestThunk.call(urllib, url, opt);
+      return yield rawRequest.call(httpclient, url, opt);
     }
+  },
+
+  mockUrllib(...args) {
+    this.deprecate('[egg-mock] Please use app.mockHttpclient instead of app.mockUrllib');
+    return this.mockHttpclient(...args);
   },
 
   /**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-    - nodejs_version: '4'
     - nodejs_version: '6'
+    - nodejs_version: '7'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "lint": "eslint lib app index.js test/*.test.js",
     "test": "npm run lint && npm run test-local",
-    "test-local": "egg-bin test -r intelli-espower-loader",
-    "cov": "egg-bin cov -r intelli-espower-loader",
+    "test-local": "egg-bin test",
+    "cov": "egg-bin cov",
     "ci": "npm run lint && npm run cov",
     "autod": "autod",
     "autod-china": "autod --registry=https://registry.npm.taobao.org",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "autod": "^2.7.1",
-    "egg": "^0.5.0",
+    "egg": "^0.7.0",
     "egg-bin": "^1.7.0",
     "egg-ci": "^1.1.0",
     "eslint": "^3.9.1",
@@ -45,13 +45,7 @@
     "supertest": "^2.0.1"
   },
   "ci": {
-    "type": "travis, appveyor",
-    "npminstall": true,
-    "version": [
-      "4",
-      "6"
-    ],
-    "command": "ci"
+    "version": "6, 7"
   },
   "homepage": "https://github.com/eggjs/egg-mock",
   "repository": {
@@ -66,7 +60,7 @@
     "mock"
   ],
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "author": "popomore <sakura9515@gmail.com>"
 }

--- a/test/fixtures/apps/mock_cookies/app/router.js
+++ b/test/fixtures/apps/mock_cookies/app/router.js
@@ -1,9 +1,9 @@
 'use strict';
 
 module.exports = function(app) {
-  app.get('/', function*() {
+  app.get('/', function* () {
     this.body = {
-      cookieValue: this.getCookie('foo') || undefined,
+      cookieValue: this.cookies.get('foo') || undefined,
       cookiesValue: this.cookies.get('foo') || undefined,
     };
   });

--- a/test/fixtures/demo/app/controller/home.js
+++ b/test/fixtures/demo/app/controller/home.js
@@ -39,10 +39,10 @@ exports.urllib = function* () {
   const url = 'http://' + this.host;
   const method = this.query.method || 'request';
   const dataType = this.query.dataType;
-  const r1 = yield this.app.urllib[method](url + '/mock_url', {
+  const r1 = yield this.app.httpclient[method](url + '/mock_url', {
     dataType,
   });
-  const r2 = yield this.app.urllib[method](url + '/mock_url', {
+  const r2 = yield this.app.httpclient[method](url + '/mock_url', {
     method: 'POST',
     dataType,
   });
@@ -63,6 +63,6 @@ exports.mockUrlPost = function* () {
 exports.mockUrllibHeaders = function* () {
   const url = 'http://' + this.host;
   const method = this.query.method || 'request';
-  const res = yield this.app.urllib[method](url + '/mock_url');
+  const res = yield this.app.httpclient[method](url + '/mock_url');
   this.body = res.headers;
 };

--- a/test/mock_cookies.test.js
+++ b/test/mock_cookies.test.js
@@ -7,7 +7,6 @@ const mm = require('..');
 const fixtures = path.join(__dirname, 'fixtures');
 
 describe('test/mock_cookies.test.js', () => {
-
   let app;
   before(done => {
     app = mm.app({
@@ -20,7 +19,7 @@ describe('test/mock_cookies.test.js', () => {
 
   it('should not return when don\'t mock cookies', done => {
     const ctx = app.mockContext();
-    assert(!ctx.getCookie('foo'));
+    assert(!ctx.cookies.get('foo'));
 
     request(app.callback())
     .get('/')
@@ -35,7 +34,7 @@ describe('test/mock_cookies.test.js', () => {
       foo: 'bar cookie',
     });
     const ctx = app.mockContext();
-    assert(ctx.getCookie('foo') === 'bar cookie');
+    assert(ctx.cookies.get('foo') === 'bar cookie');
 
     request(app.callback())
     .get('/')

--- a/test/mock_httpclient.test.js
+++ b/test/mock_httpclient.test.js
@@ -7,8 +7,7 @@ const assert = require('power-assert');
 const mm = require('..');
 const fixtures = path.join(__dirname, 'fixtures');
 
-describe('test/mock_urllib.test.js', () => {
-
+describe('test/mock_httpclient.test.js', () => {
   let app;
   let server;
   let url;
@@ -28,7 +27,7 @@ describe('test/mock_urllib.test.js', () => {
   it('should mock url get and get reponse event on urllib', done => {
     done = pedding(2, done);
     app.mockCsrf();
-    app.mockUrllib(url, {
+    app.mockHttpclient(url, {
       data: new Buffer('mock url get'),
     });
 
@@ -40,7 +39,7 @@ describe('test/mock_urllib.test.js', () => {
     })
     .expect(200, done);
 
-    app.urllib.once('response', function(result) {
+    app.httpclient.once('response', function(result) {
       assert.deepEqual(result.res, {
         status: 200,
         statusCode: 200,
@@ -56,7 +55,7 @@ describe('test/mock_urllib.test.js', () => {
 
   it('should mock url post', done => {
     app.mockCsrf();
-    app.mockUrllib(url, 'post', {
+    app.mockHttpclient(url, 'post', {
       data: new Buffer('mock url post'),
     });
 
@@ -71,10 +70,10 @@ describe('test/mock_urllib.test.js', () => {
 
   it('should mock url get and post', done => {
     app.mockCsrf();
-    app.mockUrllib(url, {
+    app.mockHttpclient(url, {
       data: 'mock url get',
     });
-    app.mockUrllib(url, 'post', {
+    app.mockHttpclient(url, 'post', {
       data: 'mock url post',
     });
 
@@ -89,10 +88,10 @@ describe('test/mock_urllib.test.js', () => {
 
   it('should support request', done => {
     app.mockCsrf();
-    app.mockUrllib(url, {
+    app.mockHttpclient(url, {
       data: 'mock url get',
     });
-    app.mockUrllib(url, 'post', {
+    app.mockHttpclient(url, 'post', {
       data: 'mock url post',
     });
 
@@ -107,10 +106,10 @@ describe('test/mock_urllib.test.js', () => {
 
   it('should support curl', done => {
     app.mockCsrf();
-    app.mockUrllib(url, {
+    app.mockHttpclient(url, {
       data: 'mock url get',
     });
-    app.mockUrllib(url, 'post', {
+    app.mockHttpclient(url, 'post', {
       data: 'mock url post',
     });
 
@@ -125,10 +124,10 @@ describe('test/mock_urllib.test.js', () => {
 
   it('should support json', done => {
     app.mockCsrf();
-    app.mockUrllib(url, {
+    app.mockHttpclient(url, {
       data: { method: 'get' },
     });
-    app.mockUrllib(url, 'post', {
+    app.mockHttpclient(url, 'post', {
       data: { method: 'post' },
     });
 
@@ -143,10 +142,10 @@ describe('test/mock_urllib.test.js', () => {
 
   it('should support text', done => {
     app.mockCsrf();
-    app.mockUrllib(url, {
+    app.mockHttpclient(url, {
       data: 'mock url get',
     });
-    app.mockUrllib(url, 'post', {
+    app.mockHttpclient(url, 'post', {
       data: 'mock url post',
     });
 
@@ -160,6 +159,17 @@ describe('test/mock_urllib.test.js', () => {
   });
 
   it('should exits req headers', done => {
+    app.mockCsrf();
+    app.mockHttpclient(url, {
+      data: 'mock url test',
+    });
+    request(server)
+    .get('/mock_urllib')
+    .expect({})
+    .expect(200, done);
+  });
+
+  it('should deprecate mockUrllib', done => {
     app.mockCsrf();
     app.mockUrllib(url, {
       data: 'mock url test',


### PR DESCRIPTION
closes https://github.com/eggjs/egg/issues/243

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
