### PR TITLE
fix: ignore all error on cluster mock restore

### DIFF
--- a/lib/request_call_function.js
+++ b/lib/request_call_function.js
@@ -15,9 +15,20 @@ httpclient.request(url, {
   dataType: 'json',
 }, (err, data) => {
   if (err) {
+    // ignore ECONNREFUSED error on mockRestore
+    if (method === 'mockRestore' && err.message.includes('ECONNREFUSED')) {
+      process.exit(0);
+    }
+
     console.error('POST %s error, method: %s, args: %j', url, method, args);
     console.error(err.stack);
-    process.exit(1);
+
+    // ignore all error on mockRestore
+    if (method === 'mockRestore') {
+      process.exit(0);
+    } else {
+      process.exit(1);
+    }
   }
   if (!data.success) {
     console.error('POST %s error, method: %s, args: %j', url, method, args);

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "await-event": "^2.1.0",
     "co": "^4.6.0",
-    "coffee": "^3.3.0",
+    "coffee": "^3.3.1",
     "debug": "^2.6.6",
-    "detect-port": "^1.1.1",
+    "detect-port": "^1.1.2",
     "egg-utils": "^2.1.0",
     "get-ready": "^2.0.1",
     "is-type-of": "^1.0.0",
@@ -47,8 +47,9 @@
     "egg-bin": "^3.3.2",
     "egg-ci": "^1.6.0",
     "eslint": "^3.19.0",
-    "eslint-config-egg": "^4.0.0",
+    "eslint-config-egg": "^4.1.0",
     "mkdirp": "^0.5.1",
+    "mz-modules": "^1.0.0",
     "pedding": "^1.1.0",
     "sdk-base": "^3.0.1",
     "ts-node": "^3.0.4",
@@ -63,7 +64,7 @@
     "url": "git@github.com:eggjs/egg-mock.git"
   },
   "bugs": {
-    "url": "https://github.com/eggjs/egg-mock/issues"
+    "url": "https://github.com/eggjs/egg/issues"
   },
   "keywords": [
     "egg",

--- a/test/fixtures/apps/app-throw/app/router.js
+++ b/test/fixtures/apps/app-throw/app/router.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/throw', function* () {
+    this.body = 'foo';
+    setTimeout(() => {
+      a.b = c;
+    }, 1);
+  });
+
+  app.get('/throw-unhandledRejection', function* () {
+    this.body = 'foo';
+    new Promise((resolve, reject) => {
+      reject(new Error('foo reject error'));
+    });
+  });
+
+  app.get('/throw-unhandledRejection-string', function* () {
+    this.body = 'foo';
+    new Promise((resolve, reject) => {
+      reject('foo reject string error');
+    });
+  });
+
+  app.get('/throw-unhandledRejection-obj', function* () {
+    this.body = 'foo';
+    new Promise((resolve, reject) => {
+      const err = {
+        name: 'TypeError',
+        message: 'foo reject obj error',
+        stack: new Error().stack,
+        toString() {
+          return this.name + ': ' + this.message;
+        },
+      };
+      reject(err);
+    });
+  });
+};

--- a/test/fixtures/apps/app-throw/config/config.default.js
+++ b/test/fixtures/apps/app-throw/config/config.default.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.keys = 'test key';

--- a/test/fixtures/apps/app-throw/config/config.unittest.js
+++ b/test/fixtures/apps/app-throw/config/config.unittest.js
@@ -1,0 +1,5 @@
+'use strict';
+
+exports.logger = {
+  consoleLevel: 'NONE',
+};

--- a/test/fixtures/apps/app-throw/package.json
+++ b/test/fixtures/apps/app-throw/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "app-throw"
+}

--- a/test/mock_cluster_restore.test.js
+++ b/test/mock_cluster_restore.test.js
@@ -1,8 +1,14 @@
 'use strict';
 
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const sleep = require('mz-modules/sleep');
 const mm = require('..');
 
-describe('test/mock_cluster_restore.test.js', () => {
+const fixtures = path.join(__dirname, 'fixtures');
+
+describe.only('test/mock_cluster_restore.test.js', () => {
   let app;
   before(() => {
     app = mm.cluster({
@@ -34,5 +40,28 @@ describe('test/mock_cluster_restore.test.js', () => {
     yield app.httpRequest()
       .get('/session')
       .expect({});
+  });
+
+  describe('handle uncaughtException', () => {
+    let app;
+    before(() => {
+      app = mm.cluster({
+        baseDir: 'apps/app-throw',
+      });
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('should handle uncaughtException and log it', function* () {
+      yield app.httpRequest()
+        .get('/throw')
+        .expect('foo')
+        .expect(200);
+
+      yield sleep(1100);
+      const logfile = path.join(fixtures, 'apps/app-throw/logs/app-throw/common-error.log');
+      const body = fs.readFileSync(logfile, 'utf8');
+      assert(body.includes('ReferenceError: a is not defined (uncaughtException throw'));
+    });
   });
 });

--- a/test/mock_cluster_restore.test.js
+++ b/test/mock_cluster_restore.test.js
@@ -8,7 +8,7 @@ const mm = require('..');
 
 const fixtures = path.join(__dirname, 'fixtures');
 
-describe.only('test/mock_cluster_restore.test.js', () => {
+describe('test/mock_cluster_restore.test.js', () => {
   let app;
   before(() => {
     app = mm.cluster({


### PR DESCRIPTION
closes https://github.com/eggjs/egg/issues/888

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
