### PR TITLE
chore: refactor d.ts

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('power-assert');
-const mock = require('./index');
+const mock = require('./index').default;
 
 const options = {};
 if (process.env.EGG_BASE_DIR) options.baseDir = process.env.EGG_BASE_DIR;

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,5 +120,5 @@ export interface EggMock {
    */
   restore(): void;
 }
-declare const mm:EggMock;
+declare const mm: EggMock;
 export default mm;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,61 +1,58 @@
 import { Application, Context } from 'egg';
 
-declare module 'egg' {
-  export interface Application { // tslint:disble-line
-    ready(): Promise<void>;
-    close(): Promise<void>;
-    callback(): any;
+export interface BaseMockApplication<T, C> extends Application { // tslint:disble-line
+  ready(): Promise<void>;
+  close(): Promise<void>;
+  callback(): any;
 
-    /**
-     * mock Context
-     */
-    mockContext(data?: any): Context;
+  /**
+   * mock Context
+   */
+  mockContext(data?: any): C;
 
-    /**
-     * mock cookie session
-     */
-    mockSession(data: any): Application;
+  /**
+   * mock cookie session
+   */
+  mockSession(data: any): T;
 
-    mockCookies(cookies: any): Application;
+  mockCookies(cookies: any): T;
 
-    mockHeaders(headers: any): Application;
+  mockHeaders(headers: any): T;
 
-    /**
-     * Mock service
-     */
-    mockService(service: string, methodName: string, fn: any): Application;
+  /**
+   * Mock service
+   */
+  mockService(service: string, methodName: string, fn: any): T;
 
-    /**
-     * mock service that return error
-     */
-    mockServiceError(service: string, methodName: string, err?: Error): Application;
+  /**
+   * mock service that return error
+   */
+  mockServiceError(service: string, methodName: string, err?: Error): T;
 
-    mockHttpclient(mockUrl: string, mockMethod: string | string[], mockResult: {
-      data?: Buffer | string | JSON;
-      status?: number;
-      headers?: any;
-    }): Application;
+  mockHttpclient(mockUrl: string, mockMethod: string | string[], mockResult: {
+    data?: Buffer | string | JSON;
+    status?: number;
+    headers?: any;
+  }): Application;
 
-    mockHttpclient(mockUrl: string, mockResult: {
-      data?: Buffer | string | JSON;
-      status?: number;
-      headers?: any;
-    }): Application;
+  mockHttpclient(mockUrl: string, mockResult: {
+    data?: Buffer | string | JSON;
+    status?: number;
+    headers?: any;
+  }): Application;
 
-    /**
-     * mock csrf
-     */
-    mockCsrf(): Application;
+  /**
+   * mock csrf
+   */
+  mockCsrf(): T;
 
-    /**
-     * http request helper
-     */
-    httpRequest(): any;
-  }
-
+  /**
+   * http request helper
+   */
+  httpRequest(): any;
 }
 
-interface MockOption {
+export interface MockOption {
   /**
    * The directory of the application
    */
@@ -90,16 +87,18 @@ interface MockOption {
 type EnvType = 'default' | 'test' | 'prod' | 'local' | 'unittest';
 type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'NONE';
 
-interface EggMock {
+interface MockApplication extends BaseMockApplication<Application, Context> { }
+
+export interface EggMock {
   /**
    * Create a egg mocked application
    */
-  app(option?: MockOption): Application;
+  app(option?: MockOption): MockApplication;
 
   /**
    * Create a mock cluster server, but you can't use API in application, you should test using supertest
    */
-  cluster(option?: MockOption): Application;
+  cluster(option?: MockOption): MockApplication;
 
   /**
    * mock the serverEnv of Egg
@@ -121,7 +120,5 @@ interface EggMock {
    */
   restore(): void;
 }
-
-declare var mm: EggMock;
-
-export = mm;
+declare const mm:EggMock;
+export default mm;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function mock(...args) {
   return mm(...args);
 }
 module.exports = mock;
+module.exports.default = mock;
 
 // inherit & extends mm
 Object.assign(mock, mm, {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "contributors": "ali-contributors"
   },
   "dependencies": {
+    "@types/power-assert": "^1.4.29",
     "await-event": "^2.1.0",
     "co": "^4.6.0",
     "coffee": "^4.1.0",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import * as mm from '../index';
+import mm from '../index';
 import * as path from 'path';
 const fixtures = path.join(__dirname, 'fixtures');
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -55,3 +55,13 @@ mm.home('a')
 // mm.cluster();
 
 mm.env('test');
+
+// test for bootstrap
+(global as any).before = () => {};
+(global as any).afterEach = () => {};
+
+import { mock, app as bootApp, assert } from '../bootstrap';
+bootApp.ready;
+mock.restore;
+assert(true);
+mock.app;


### PR DESCRIPTION
index.d.ts 重构，直接把 mm 挂到 default 上，同时可以把其他一些 interface 暴露出来，给其他应用使用。