### PR TITLE
fix: allow egg-core module missing

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,16 +1,26 @@
 'use strict';
 
-let eggUtils = require('egg-core').utils;
-if (!eggUtils) {
-  // try to support egg-core@3
-  eggUtils = require('egg-core/lib/utils');
+// try to use eggUtils.getCalleeFromStack
+// ignore it if egg-core module not found
+let eggUtils;
+try {
+  eggUtils = require('egg-core').utils;
+  if (!eggUtils) {
+    // try to support egg-core@3
+    eggUtils = require('egg-core/lib/utils');
+  }
+} catch (_) {
+  // ignore eggUtils
 }
 
 module.exports = {
   runInBackground(scope) {
     /* istanbul ignore next */
-    const taskName = scope._name || scope.name || eggUtils.getCalleeFromStack(true);
-    scope._name = taskName;
+    const taskName = scope._name || scope.name || (eggUtils && eggUtils.getCalleeFromStack(true));
+    if (taskName) {
+      scope._name = taskName;
+    }
+
     const promise = this._runInBackground(scope);
     this.app._backgroundTasks.push(promise);
   },


### PR DESCRIPTION
Can use egg-mock on non-egg project.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
