### PR TITLE
fix: fix declaration merging error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ export interface EggMock extends MockMate {
 }
 
 // use Declaration Merging to avoid overload interface not match error
-interface EggMock {
+export interface EggMock {
   /**
    * restore mock
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,14 +116,10 @@ export interface EggMock extends MockMate {
    */
   home: (homePath: string) => void;
 
-}
-
-// use Declaration Merging to avoid overload interface not match error
-export interface EggMock {
   /**
    * restore mock
    */
-  restore: () => void;  
+  restore: () => any;
 }
 
 declare const mm: EggMock;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

发现通过 declaration merging 的 override 方式还是有问题，会导致 export 出去的就只剩了一个 restore 方法，把原来的 EggMock 覆盖掉了，改回 `restore: () => any`。