### PR TITLE
fix:  remove nonexistent type and correct typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,13 +31,13 @@ export interface BaseMockApplication<T, C> extends Application { // tslint:disbl
   mockServiceError(service: string, methodName: string, err?: Error): T;
 
   mockHttpclient(mockUrl: string | RegExp, mockMethod: string | string[], mockResult: {
-    data?: Buffer | string | JSON;
+    data?: string | object;
     status?: number;
     headers?: any;
   }): Application;
 
   mockHttpclient(mockUrl: string | RegExp, mockResult: {
-    data?: Buffer | string | JSON;
+    data?: string | obejct;
     status?: number;
     headers?: any;
   }): Application;


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes
- [x] commit message follows commit guidelines

##### Description of change

egg-mock 中的 [mockHttpclient](https://github.com/eggjs/egg-mock/blob/master/lib/mock_httpclient.js#L33) 参数：mockResult 这个参数中的 data item 本意可以接受 object, string 和 buffer，并最终都转为 buffer string 根据请求的 content-type 来做 response body 的转化。

然而在 egg-mock  的[官方 typing]() 里，却只允许传入 string，因为 JSON 和 Buffer 并不是 TypeScript 内建的类型，所以在 typescript 下并不 work，mockHttpclient 的 data 永远只能接受 string，否则无法通过 tsserver 的编译。

考虑 object 和 Buffer 都是 object，更正 typing 的文件，使得 TypeScript 下 mockHttpclient 可以和 common js 下接受的参数类型表现一致。