### PR TITLE
fix: mockHttpclient with multi-request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ matrix:
   exclude:
   - node_js: '6'
     env: EGG_VERSION=2
+before_install:
+  - npm install npminstall -g
 install:
-  - npm i npminstall
   - sed -i.bak '/"egg":/d' package.json
   - npminstall -d
 script:

--- a/lib/mock_httpclient.js
+++ b/lib/mock_httpclient.js
@@ -83,9 +83,8 @@ module.exports = function(app) {
       opt = opt || {};
       opt.method = (opt.method || 'GET').toUpperCase();
       opt.headers = opt.headers || {};
-      let mockRequestResult = mockResult;
       if (matchUrl(url) && matchMethod(opt.method)) {
-        if (is.function(mockRequestResult)) mockRequestResult = mockRequestResult(url, opt);
+        const mockRequestResult = is.function(mockResult) ? mockResult(url, opt) : mockResult;
         const result = extend(true, {}, normalizeResult(mockRequestResult));
         const response = {
           status: result.status,

--- a/lib/mock_httpclient.js
+++ b/lib/mock_httpclient.js
@@ -83,9 +83,10 @@ module.exports = function(app) {
       opt = opt || {};
       opt.method = (opt.method || 'GET').toUpperCase();
       opt.headers = opt.headers || {};
+      let mockRequestResult = mockResult;
       if (matchUrl(url) && matchMethod(opt.method)) {
-        if (is.function(mockResult)) mockResult = mockResult(url, opt);
-        const result = extend(true, {}, normalizeResult(mockResult));
+        if (is.function(mockRequestResult)) mockRequestResult = mockRequestResult(url, opt);
+        const result = extend(true, {}, normalizeResult(mockRequestResult));
         const response = {
           status: result.status,
           statusCode: result.status,

--- a/test/mock_httpclient.test.js
+++ b/test/mock_httpclient.test.js
@@ -317,7 +317,7 @@ describe('test/mock_httpclient.test.js', () => {
       .expect(200);
   });
 
-  it('should mock fn with multi-times request without error', function* () {
+  it('should mock fn with multi-request without error', function* () {
     app.mockCsrf();
     let i = 0;
     app.mockHttpclient(url, 'post', () => {

--- a/test/mock_httpclient.test.js
+++ b/test/mock_httpclient.test.js
@@ -316,4 +316,18 @@ describe('test/mock_httpclient.test.js', () => {
       })
       .expect(200);
   });
+
+  it('should mock fn with multi-times request without error', function* () {
+    app.mockCsrf();
+    let i = 0;
+    app.mockHttpclient(url, 'post', () => {
+      i++;
+      return {};
+    });
+
+    yield request(server).get('/urllib').expect(200);
+    yield request(server).get('/urllib').expect(200);
+    yield request(server).get('/urllib').expect(200);
+    assert(i === 3);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

修复当 mockResult 为函数时，发起多次请求，函数也只会执行一次的问题（ 原因是 `mockResult = mockResult()` 导致结果被缓存了 ）。
