### PR TITLE
feat: support app.notExpectLog()

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,11 +265,11 @@ Clean all logs directory, default is true.
 
 If you are using `ava`, disable it.
 
-### app.mockLog([logger]) and app.expectLog(str[, logger])
+### app.mockLog([logger]) and app.expectLog(str[, logger]), app.notExpectLog(str[, logger])
 
 Assert some string value in the logger instance.
-It is recommended to pair `app.mockLog()` with `app.expectLog()`.
-Using `app.expectLog()` alone requires dependency on the write speed of the log. When the server disk is high IO, unstable results will occur.
+It is recommended to pair `app.mockLog()` with `app.expectLog()` or `app.notExpectLog()`.
+Using `app.expectLog()` or `app.notExpectLog()` alone requires dependency on the write speed of the log. When the server disk is high IO, unstable results will occur.
 
 ```js
 it('should work', async () => {
@@ -282,6 +282,10 @@ it('should work', async () => {
   app.expectLog('foo in logger');
   app.expectLog('foo in coreLogger', 'coreLogger');
   app.expectLog('foo in myCustomLogger', 'myCustomLogger');
+
+  app.notExpectLog('bar in logger');
+  app.notExpectLog('bar in coreLogger', 'coreLogger');
+  app.notExpectLog('bar in myCustomLogger', 'myCustomLogger');
 });
 ```
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -275,11 +275,11 @@ mm.app({
 
 如果是通过 ava 等并行测试框架进行测试，需要手动在执行测试前进行统一的日志清理，不能通过 mm 来处理，设置 `clean` 为 `false`。
 
-### app.mockLog([logger]) and app.expectLog(str[, logger])
+### app.mockLog([logger]) and app.expectLog(str[, logger]), app.notExpectLog(str[, logger])
 
 断言指定的字符串记录在指定的日志中。
-建议 `app.mockLog()` 和 `app.expectLog()` 配对使用。
-单独使用 `app.expectLog()` 需要依赖日志的写入速度，在服务器磁盘高 IO 的时候，会出现不稳定的结果。
+建议 `app.mockLog()` 和 `app.expectLog()` 或者 `app.notExpectLog()` 配对使用。
+单独使用 `app.expectLog()` 或者 `app.notExpectLog()` 需要依赖日志的写入速度，在服务器磁盘高 IO 的时候，会出现不稳定的结果。
 
 ```js
 it('should work', async () => {
@@ -293,6 +293,10 @@ it('should work', async () => {
   app.expectLog('foo in logger');
   app.expectLog('foo in coreLogger', 'coreLogger');
   app.expectLog('foo in myCustomLogger', 'myCustomLogger');
+
+  app.notExpectLog('bar in logger');
+  app.notExpectLog('bar in coreLogger', 'coreLogger');
+  app.notExpectLog('bar in myCustomLogger', 'myCustomLogger');
 });
 ```
 

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -333,13 +333,7 @@ module.exports = {
     });
   },
 
-  /**
-   * expect str/regexp in the logger, if your server disk is slow, please call `mockLog()` first.
-   * @param {String|RegExp} str - test str or regexp
-   * @param {String|Logger} [logger] - logger instance, default is `ctx.logger`
-   * @function App#expectLog
-   */
-  expectLog(str, logger) {
+  __checkExpectLog(expectOrNot, str, logger) {
     logger = logger || this.logger;
     if (typeof logger === 'string') {
       logger = this.getLogger(logger);
@@ -351,12 +345,40 @@ module.exports = {
     } else {
       content = fs.readFileSync(filepath, 'utf8');
     }
+    let match;
+    let type;
     if (str instanceof RegExp) {
-      assert(str.test(content), `Can't find RegExp:"${str}" in ${filepath}, log content: ...${content.substring(content.length - 500)}`);
+      match = str.test(content);
+      type = 'RegExp';
     } else {
-      str = String(str);
-      assert(content.includes(str), `Can't find String:"${str}" in ${filepath}, log content: ...${content.substring(content.length - 500)}`);
+      match = content.includes(String(str));
+      type = 'String';
     }
+    if (expectOrNot) {
+      assert(match, `Can't find ${type}:"${str}" in ${filepath}, log content: ...${content.substring(content.length - 500)}`);
+    } else {
+      assert(!match, `Find ${type}:"${str}" in ${filepath}, log content: ...${content.substring(content.length - 500)}`);
+    }
+  },
+
+  /**
+   * expect str/regexp in the logger, if your server disk is slow, please call `mockLog()` first.
+   * @param {String|RegExp} str - test str or regexp
+   * @param {String|Logger} [logger] - logger instance, default is `ctx.logger`
+   * @function App#expectLog
+   */
+  expectLog(str, logger) {
+    this.__checkExpectLog(true, str, logger);
+  },
+
+  /**
+   * not expect str/regexp in the logger, if your server disk is slow, please call `mockLog()` first.
+   * @param {String|RegExp} str - test str or regexp
+   * @param {String|Logger} [logger] - logger instance, default is `ctx.logger`
+   * @function App#notExpectLog
+   */
+  notExpectLog(str, logger) {
+    this.__checkExpectLog(false, str, logger);
   },
 
   // private method

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -214,6 +214,19 @@ class ClusterApplication extends Coffee {
     this._callFunctionOnAppWorker('expectLog', [ str, logger ], null, true);
   }
 
+  /**
+   * not expect str in the logger
+   * it's different from `app.notExpectLog()`, only support string params.
+   *
+   * @param {String} str - test str
+   * @param {String} [logger] - logger instance name, default is `logger`
+   * @function ClusterApplication#notExpectLog
+   */
+  notExpectLog(str, logger) {
+    logger = logger || 'logger';
+    this._callFunctionOnAppWorker('notExpectLog', [ str, logger ], null, true);
+  }
+
   httpRequest() {
     return supertestRequest(this);
   }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -106,7 +106,7 @@ function call(method) {
         });
     });
 
-    it('should app.expectLog() work', function* () {
+    it('should app.expectLog(), app.notExpectLog() work', function* () {
       yield app.httpRequest()
         .get('/logger')
         .expect(200)
@@ -117,11 +117,20 @@ function call(method) {
       app.expectLog('[app.expectLog() test] ok', 'logger');
       app.expectLog('[app.expectLog(coreLogger) test] ok', 'coreLogger');
 
+      app.notExpectLog('[app.notExpectLog() test] fail');
+      app.notExpectLog('[app.notExpectLog() test] fail', 'logger');
+      app.notExpectLog('[app.notExpectLog(coreLogger) test] fail', 'coreLogger');
+
       if (method === 'app') {
         app.expectLog(/\[app\.expectLog\(\) test\] ok/);
         app.expectLog(/\[app\.expectLog\(\) test\] ok/, app.logger);
         app.expectLog('[app.expectLog(coreLogger) test] ok', app.coreLogger);
         app.expectLog(/\[app\.expectLog\(coreLogger\) test\] ok/, 'coreLogger');
+
+        app.notExpectLog(/\[app\.notExpectLog\(\) test\] fail/);
+        app.notExpectLog(/\[app\.notExpectLog\(\) test\] fail/, app.logger);
+        app.notExpectLog('[app.notExpectLog(coreLogger) test] fail', app.coreLogger);
+        app.notExpectLog(/\[app\.notExpectLog\(coreLogger\) test\] fail/, 'coreLogger');
       }
 
       try {
@@ -129,6 +138,14 @@ function call(method) {
         throw new Error('should not run this');
       } catch (err) {
         assert(err.message.includes('Can\'t find String:"[app.expectLog(coreLogger) test] ok" in '));
+        assert(err.message.includes('app-web.log'));
+      }
+
+      try {
+        app.notExpectLog('[app.expectLog() test] ok');
+        throw new Error('should not run this');
+      } catch (err) {
+        assert(err.message.includes('Find String:"[app.expectLog() test] ok" in '));
         assert(err.message.includes('app-web.log'));
       }
     });
@@ -147,11 +164,20 @@ function call(method) {
       app.expectLog('[app.expectLog() test] ok', 'logger');
       app.expectLog('[app.expectLog(coreLogger) test] ok', 'coreLogger');
 
+      app.notExpectLog('[app.notExpectLog() test] fail');
+      app.notExpectLog('[app.notExpectLog() test] fail', 'logger');
+      app.notExpectLog('[app.notExpectLog(coreLogger) test] fail', 'coreLogger');
+
       if (method === 'app') {
         app.expectLog(/\[app\.expectLog\(\) test\] ok/);
         app.expectLog(/\[app\.expectLog\(\) test\] ok/, app.logger);
         app.expectLog('[app.expectLog(coreLogger) test] ok', app.coreLogger);
         app.expectLog(/\[app\.expectLog\(coreLogger\) test\] ok/, 'coreLogger');
+
+        app.notExpectLog(/\[app\.notExpectLog\(\) test\] fail/);
+        app.notExpectLog(/\[app\.notExpectLog\(\) test\] fail/, app.logger);
+        app.notExpectLog('[app.notExpectLog(coreLogger) test] fail', app.coreLogger);
+        app.notExpectLog(/\[app\.notExpectLog\(coreLogger\) test\] fail/, 'coreLogger');
       }
 
       try {
@@ -159,6 +185,14 @@ function call(method) {
         throw new Error('should not run this');
       } catch (err) {
         assert(err.message.includes('Can\'t find String:"[app.expectLog(coreLogger) test] ok" in '));
+        assert(err.message.includes('app-web.log'));
+      }
+
+      try {
+        app.notExpectLog('[app.expectLog() test] ok');
+        throw new Error('should not run this');
+      } catch (err) {
+        assert(err.message.includes('Find String:"[app.expectLog() test] ok" in '));
         assert(err.message.includes('app-web.log'));
       }
 


### PR DESCRIPTION
just like app.expectLog(), but negate

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
