### PR TITLE
fix: single mode will call app.agent.close

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -26,7 +26,6 @@ const MOCK_APP_METHOD = [
   'ready',
   'closed',
   'close',
-  'agent',
   '_agent',
   '_app',
   'on',
@@ -81,6 +80,12 @@ class MockApplication extends EventEmitter {
 
     const Application = bindMessenger(egg.Application, agent);
     const app = this._app = new Application(Object.assign({}, this.options));
+
+    // https://github.com/eggjs/egg/blob/8bb7c7e7d59d6aeca4b2ed1eb580368dcb731a4d/lib/egg.js#L125
+    // egg single mode mount this at start(), so egg-mock should impel it.
+    app.agent = agent;
+    agent.app = app;
+
     // egg-mock plugin need to override egg context
     Object.assign(app.context, context);
     mockCustomLoader(app);
@@ -162,11 +167,6 @@ class MockApplication extends EventEmitter {
       if (os.platform() === 'win32') yield sleep(1000);
     });
   }
-
-  get agent() {
-    return this._agent;
-  }
-
 }
 
 module.exports = function(options) {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -23,6 +23,7 @@ describe('test/app.test.js', () => {
     });
     yield app.ready();
     assert(app.agent === app._agent);
+    assert(app.agent.app === app._app);
   });
 
   it('should not use cache when app is closed', function* () {

--- a/test/app_proxy.test.js
+++ b/test/app_proxy.test.js
@@ -239,7 +239,6 @@ describe('test/app_proxy.test.js', () => {
         'ready',
         'closed',
         'close',
-        'agent',
         '_agent',
         '_app',
         'on',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

https://github.com/eggjs/egg/blob/8bb7c7e7d59d6aeca4b2ed1eb580368dcb731a4d/lib/egg.js#L125

如果不设置的话，mm.app({ single }) 后 调用 app.close 会报错，因为 egg 里面的挂载是在 start 里面的，mm.app 没走 start，先这么处理了，等 runtime 里面的 createInstance 下沉后，egg-mock 这块可以改为直接调用它就统一了。