### PR TITLE
feat: support init hook before mock app init

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -56,6 +56,10 @@ class MockApplication extends EventEmitter {
   }
 
   * [INIT]() {
+    if (this.options.beforeInit) {
+      yield this.options.beforeInit(this);
+      delete this.options.beforeInit;
+    }
     if (this.options.clean !== false) {
       const logDir = path.join(this.options.baseDir, 'logs');
       try {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -66,6 +66,26 @@ describe('test/app.test.js', () => {
     yield app.close();
   });
 
+  it('support options.beforeInit', function* () {
+    const baseDir = path.join(fixtures, 'app');
+    const app = mm.app({
+      baseDir,
+      customEgg: path.join(__dirname, '../node_modules/egg'),
+      cache: false,
+      beforeInit(instance) {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            instance.options.test = 'abc';
+            resolve();
+          }, 100);
+        });
+      },
+    });
+    yield app.ready();
+    assert(!app.options.beforeInit);
+    assert(app.options.test === 'abc');
+  });
+
   // TODO: implement ready(err)
   it.skip('should emit error when load Application fail', done => {
     const baseDir = path.join(fixtures, 'app-fail');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

sff mock 那块，还是想改为继承方式，在 mock app init 之前加个钩子，用来初始化代码。