### PR TITLE
fix: enable sendRandom() method in unittest

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -247,6 +247,17 @@ function bindMessenger(Application, agent) {
     constructor(options) {
       super(options);
 
+      // enable app to send to a random agent
+      this.messenger.sendRandom = (action, data) => {
+        this.messenger.sendToAgent(action, data);
+      };
+      // enable agent to send to a random app
+      agentMessenger.on('egg-ready', () => {
+        agentMessenger.sendRandom = (action, data) => {
+          agentMessenger.sendToApp(action, data);
+        };
+      });
+
       agentMessenger.send = new Proxy(agentMessenger.send, {
         apply: this._sendMessage.bind(this),
       });

--- a/test/app_proxy.test.js
+++ b/test/app_proxy.test.js
@@ -266,13 +266,17 @@ describe('test/app_proxy.test.js', () => {
       assert.deepEqual(app._agent.received, [
         'send data when app starting',
         'send data when app started',
+        'send data to a random agent',
       ]);
     });
 
     it('should send message from agent to app', () => {
-      assert.deepEqual(app._app.received, [
-        'send data when server started',
-      ]);
+      process.nextTick(() => {
+        assert.deepEqual(app._app.received, [
+          'send data when server started',
+          'send data to a random app',
+        ]);
+      });
     });
 
     it('should receive egg-ready', () => {

--- a/test/fixtures/messenger-binding/agent.js
+++ b/test/fixtures/messenger-binding/agent.js
@@ -15,6 +15,7 @@ module.exports = agent => {
   });
   agent.messenger.on('egg-ready', () => {
     agent.messenger.sendToApp('action', 'send data when server started');
+    process.nextTick(() => agent.messenger.sendRandom('action', 'send data to a random app'));
   });
   agent.messenger.on('egg-ready', data => {
     agent.eggReady = true;

--- a/test/fixtures/messenger-binding/app.js
+++ b/test/fixtures/messenger-binding/app.js
@@ -20,6 +20,7 @@ module.exports = app => {
 
   app.ready(() => {
     app.messenger.sendToAgent('action', 'send data when app started');
+    app.messenger.sendRandom('action', 'send data to a random agent')
     app.messenger.broadcast('broadcast-action', 'broadcast action');
     app.messenger.sendToApp('app-action', 'send action to app');
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
egg-mock


##### Description of change
<!-- Provide a description of the change below this comment. -->
Replace messenger.sendRandom() method with messenger.sendToApp() or messenger.sendToAgent(). Thus app and agent can normally send to random app/agent in unittest. 

related issue: https://github.com/eggjs/egg/issues/3989 https://github.com/eggjs/egg/issues/4055
reference: https://github.com/eggjs/egg-mock/pull/94/files
