### PR TITLE
[fix] fix run server without wait until app ready

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -103,8 +103,8 @@ class MockApplication extends EventEmitter {
     debug('this[APP_INIT] = true');
     this[BIND_EVENT]();
     debug('http server instantiate');
-    mockHttpServer(app);
     yield app.ready();
+    mockHttpServer(app);
 
     const msg = {
       action: 'egg-ready',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

mock server need to be started after app ready, be cause router plugin are run in beforeHook, now I can't do the api test, even the buildin unit test are failed.

before:
![image](https://user-images.githubusercontent.com/8176600/165932149-5601df49-31b5-4016-b7c2-d4a3a9ebc84d.png)

after:
![image](https://user-images.githubusercontent.com/8176600/165932211-fe8b1a92-6bf5-4dc7-b962-71aa42783624.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ *] `npm test` passes
- [ *] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ *] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
