### PR TITLE
fix: allow other envtype

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,7 +106,7 @@ export interface MockOption {
   clean?: boolean;
 }
 
-type EnvType = 'default' | 'test' | 'prod' | 'local' | 'unittest';
+type EnvType = 'default' | 'test' | 'prod' | 'local' | 'unittest' | string & {};
 type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'NONE';
 
 export interface MockApplication extends BaseMockApplication<Application, Context> { }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,3 +15,5 @@ expectType<void>(app.expectLog('foo string', app.coreLogger));
 expectType<void>(app.expectLog(/foo string/));
 expectType<void>(app.expectLog(/foo string/, 'coreLogger'));
 expectType<void>(app.expectLog(/foo string/, app.coreLogger));
+expectType<void>(mm.env('default'));
+expectType<void>(mm.env('devserver'));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

##### Description of change
<!-- Provide a description of the change below this comment. -->

<img width="660" alt="image" src="https://user-images.githubusercontent.com/5856440/168718117-11109872-c90b-4fcb-8762-45ecea024e03.png">

支持已有 env 类型提示的前提下，也能传入其他环境类型不抛错
