### PR TITLE
feat: impl parallel app for mocha parallel mode

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -41,6 +41,6 @@ jobs:
       run: npm run ci
 
     - name: Code Coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -3,15 +3,21 @@
 const assert = require('power-assert');
 const path = require('path');
 const mock = require('./index').default;
+const mockParallelApp = require('./lib/parallel/app');
+const { getEggOptions } = require('./lib/utils');
 
-const options = {};
-if (process.env.EGG_BASE_DIR) options.baseDir = process.env.EGG_BASE_DIR;
+const options = getEggOptions();
 
 // throw error when an egg plugin test is using bootstrap
 const pkgInfo = require(path.join(options.baseDir || process.cwd(), 'package.json'));
 if (pkgInfo.eggPlugin) throw new Error('DO NOT USE bootstrap to test plugin');
 
-const app = mock.app(options);
+let app;
+if (process.env.ENABLE_MOCHA_PARALLEL && process.env.AUTO_AGENT) {
+  app = mockParallelApp(options);
+} else {
+  app = mock.app(options);
+}
 
 if (typeof beforeAll === 'function') {
   // jest

--- a/lib/parallel/agent.js
+++ b/lib/parallel/agent.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const debug = require('debug')('egg-mock');
+const Base = require('sdk-base');
+const path = require('path');
+const detectPort = require('detect-port');
+
+const context = require('../context');
+const formatOptions = require('../format_options');
+const { sleep, rimraf } = require('../utils');
+const mockCustomLoader = require('../mock_custom_loader');
+
+const {
+  APP_INIT,
+  INIT_ONCE_LISTENER,
+  INIT_ON_LISTENER,
+  BIND_EVENT,
+  consoleLogger,
+} = require('./util');
+
+class MockAgent extends Base {
+  constructor(options) {
+    super({ initMethod: '_init' });
+    this.options = options;
+    this.baseDir = options.baseDir;
+    this.closed = false;
+    this[APP_INIT] = false;
+    this[INIT_ON_LISTENER] = new Set();
+    this[INIT_ONCE_LISTENER] = new Set();
+    // listen once, otherwise will throw exception when emit error without listenr
+    this.once('error', err => {
+      consoleLogger.error(err);
+    });
+  }
+
+  async _init() {
+    if (this.options.beforeInit) {
+      await this.options.beforeInit(this);
+      delete this.options.beforeInit;
+    }
+    if (this.options.clean !== false) {
+      const logDir = path.join(this.options.baseDir, 'logs');
+      try {
+        await rimraf(logDir);
+      } catch (err) {
+        /* istanbul ignore next */
+        console.error(`remove log dir ${logDir} failed: ${err.stack}`);
+      }
+    }
+
+    this.options.clusterPort = process.env.CLUSTER_PORT = await detectPort();
+    debug('get clusterPort %s', this.options.clusterPort);
+    const { Agent } = require(this.options.framework);
+
+    const agent = this._instance = new Agent(Object.assign({}, this.options));
+
+    // egg-mock plugin need to override egg context
+    Object.assign(agent.context, context);
+    mockCustomLoader(agent);
+
+    debug('agent instantiate');
+    this[APP_INIT] = true;
+    debug('this[APP_INIT] = true');
+    this[BIND_EVENT]();
+    debug('http server instantiate');
+    await agent.ready();
+
+    const msg = {
+      action: 'egg-ready',
+      data: this.options,
+    };
+    agent.messenger._onMessage(msg);
+    debug('agent ready');
+  }
+
+  [BIND_EVENT]() {
+    for (const args of this[INIT_ON_LISTENER]) {
+      debug('on(%s), use cache and pass to app', args);
+      this._instance.on(...args);
+      this.removeListener(...args);
+    }
+    for (const args of this[INIT_ONCE_LISTENER]) {
+      debug('once(%s), use cache and pass to app', args);
+      this._instance.on(...args);
+      this.removeListener(...args);
+    }
+  }
+
+  on(...args) {
+    if (this[APP_INIT]) {
+      debug('on(%s), pass to app', args);
+      this._instance.on(...args);
+    } else {
+      debug('on(%s), cache it because app has not init', args);
+      if (this[INIT_ON_LISTENER]) {
+        this[INIT_ON_LISTENER].add(args);
+      }
+      super.on(...args);
+    }
+  }
+
+  once(...args) {
+    if (this[APP_INIT]) {
+      debug('once(%s), pass to app', args);
+      this._instance.once(...args);
+    } else {
+      debug('once(%s), cache it because app has not init', args);
+      if (this[INIT_ONCE_LISTENER]) {
+        this[INIT_ONCE_LISTENER].add(args);
+      }
+      super.on(...args);
+    }
+  }
+
+  /**
+   * close app
+   * @return {Promise} promise
+   */
+  async close() {
+    this.closed = true;
+    const self = this;
+    if (self._instance) {
+      await self._instance.close();
+    } else {
+      // when app init throws an exception, must wait for app quit gracefully
+      await sleep(200);
+    }
+  }
+}
+
+module.exports = function(options) {
+  options = formatOptions(options);
+
+  return new MockAgent(options);
+};

--- a/lib/parallel/agent_register.js
+++ b/lib/parallel/agent_register.js
@@ -1,0 +1,14 @@
+const Agent = require('./agent');
+const { getEggOptions } = require('../utils');
+
+let agent;
+exports.mochaGlobalSetup = async () => {
+  agent = Agent(getEggOptions());
+  await agent.ready();
+};
+
+exports.mochaGlobalTeardown = async () => {
+  if (agent) {
+    await agent.close();
+  }
+};

--- a/lib/parallel/app.js
+++ b/lib/parallel/app.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const debug = require('debug')('egg-mock');
+const Base = require('sdk-base');
+
+const context = require('../context');
+const formatOptions = require('../format_options');
+const { sleep } = require('../utils');
+const mockCustomLoader = require('../mock_custom_loader');
+const mockHttpServer = require('../mock_http_server');
+const {
+  proxyApp,
+  APP_INIT,
+  INIT_ONCE_LISTENER,
+  INIT_ON_LISTENER,
+  BIND_EVENT,
+  consoleLogger,
+} = require('./util');
+
+class MockApplication extends Base {
+  constructor(options) {
+    super({ initMethod: '_init' });
+    this.options = options;
+    this.baseDir = options.baseDir;
+    this.closed = false;
+    this[APP_INIT] = false;
+    this[INIT_ON_LISTENER] = new Set();
+    this[INIT_ONCE_LISTENER] = new Set();
+    // listen once, otherwise will throw exception when emit error without listenr
+    this.once('error', err => {
+      consoleLogger.error(err);
+    });
+  }
+
+  async _init() {
+    if (this.options.beforeInit) {
+      await this.options.beforeInit(this);
+      delete this.options.beforeInit;
+    }
+
+    this.options.clusterPort = process.env.CLUSTER_PORT;
+    debug('get clusterPort %s', this.options.clusterPort);
+    const { Application } = require(this.options.framework);
+
+    const app = this._instance = new Application(Object.assign({}, this.options));
+
+    // egg-mock plugin need to override egg context
+    Object.assign(app.context, context);
+    mockCustomLoader(app);
+
+    debug('app instantiate');
+    this[APP_INIT] = true;
+    debug('this[APP_INIT] = true');
+    this[BIND_EVENT]();
+    debug('http server instantiate');
+    mockHttpServer(app);
+    await app.ready();
+
+    const msg = {
+      action: 'egg-ready',
+      data: this.options,
+    };
+    app.messenger._onMessage(msg);
+    debug('app ready');
+  }
+
+  [BIND_EVENT]() {
+    for (const args of this[INIT_ON_LISTENER]) {
+      debug('on(%s), use cache and pass to app', args);
+      this._instance.on(...args);
+      this.removeListener(...args);
+    }
+    for (const args of this[INIT_ONCE_LISTENER]) {
+      debug('once(%s), use cache and pass to app', args);
+      this._instance.on(...args);
+      this.removeListener(...args);
+    }
+  }
+
+  on(...args) {
+    if (this[APP_INIT]) {
+      debug('on(%s), pass to app', args);
+      this._instance.on(...args);
+    } else {
+      debug('on(%s), cache it because app has not init', args);
+      if (this[INIT_ON_LISTENER]) {
+        this[INIT_ON_LISTENER].add(args);
+      }
+      super.on(...args);
+    }
+  }
+
+  once(...args) {
+    if (this[APP_INIT]) {
+      debug('once(%s), pass to app', args);
+      this._instance.once(...args);
+    } else {
+      debug('once(%s), cache it because app has not init', args);
+      if (this[INIT_ONCE_LISTENER]) {
+        this[INIT_ONCE_LISTENER].add(args);
+      }
+      super.on(...args);
+    }
+  }
+
+  /**
+   * close app
+   * @return {Promise} promise
+   */
+  async close() {
+    this.closed = true;
+    const self = this;
+    if (self._instance) {
+      await self._instance.close();
+    } else {
+      // when app init throws an exception, must wait for app quit gracefully
+      await sleep(200);
+    }
+  }
+}
+
+module.exports = function(options) {
+  options = formatOptions(options);
+
+  const app = new MockApplication(options);
+  return proxyApp(app, options);
+};

--- a/lib/parallel/util.js
+++ b/lib/parallel/util.js
@@ -1,0 +1,79 @@
+const debug = require('debug')('egg-mock');
+const { getProperty } = require('../utils');
+const ConsoleLogger = require('egg-logger').EggConsoleLogger;
+
+const consoleLogger = new ConsoleLogger({ level: 'INFO' });
+
+const MOCK_APP_METHOD = [
+  'ready',
+  'closed',
+  'close',
+  'on',
+  'once',
+];
+
+const INIT = Symbol('init');
+const APP_INIT = Symbol('appInit');
+const BIND_EVENT = Symbol('bindEvent');
+const INIT_ON_LISTENER = Symbol('initOnListener');
+const INIT_ONCE_LISTENER = Symbol('initOnceListener');
+
+function proxyApp(app) {
+  const proxyApp = new Proxy(app, {
+    get(target, prop) {
+      // don't delegate properties on MockAgent
+      if (MOCK_APP_METHOD.includes(prop)) return getProperty(target, prop);
+      if (!target[APP_INIT]) throw new Error(`can't get ${prop} before ready`);
+      // it's asyncrounus when agent and app are loading,
+      // so should get the properties after loader ready
+      debug('proxy handler.get %s', prop);
+      return target._instance[prop];
+    },
+    set(target, prop, value) {
+      if (MOCK_APP_METHOD.includes(prop)) return true;
+      if (!target[APP_INIT]) throw new Error(`can't set ${prop} before ready`);
+      debug('proxy handler.set %s', prop);
+      target._instance[prop] = value;
+      return true;
+    },
+    defineProperty(target, prop, descriptor) {
+      // can't define properties on MockAgent
+      if (MOCK_APP_METHOD.includes(prop)) return true;
+      if (!target[APP_INIT]) throw new Error(`can't defineProperty ${prop} before ready`);
+      debug('proxy handler.defineProperty %s', prop);
+      Object.defineProperty(target._instance, prop, descriptor);
+      return true;
+    },
+    deleteProperty(target, prop) {
+      // can't delete properties on MockAgent
+      if (MOCK_APP_METHOD.includes(prop)) return true;
+      if (!target[APP_INIT]) throw new Error(`can't delete ${prop} before ready`);
+      debug('proxy handler.deleteProperty %s', prop);
+      delete target._instance[prop];
+      return true;
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (MOCK_APP_METHOD.includes(prop)) return Object.getOwnPropertyDescriptor(target, prop);
+      if (!target[APP_INIT]) throw new Error(`can't getOwnPropertyDescriptor ${prop} before ready`);
+      debug('proxy handler.getOwnPropertyDescriptor %s', prop);
+      return Object.getOwnPropertyDescriptor(target._instance, prop);
+    },
+    getPrototypeOf(target) {
+      if (!target[APP_INIT]) throw new Error('can\'t getPrototypeOf before ready');
+      debug('proxy handler.getPrototypeOf %s');
+      return Object.getPrototypeOf(target._instance);
+    },
+  });
+  return proxyApp;
+}
+
+module.exports = {
+  MOCK_APP_METHOD,
+  INIT,
+  APP_INIT,
+  BIND_EVENT,
+  INIT_ON_LISTENER,
+  INIT_ONCE_LISTENER,
+  proxyApp,
+  consoleLogger,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 const util = require('util');
 const { rm } = require('fs/promises');
 const { rmSync } = require('fs');
+const is = require('is-type-of');
 
 const setTimeoutPromise = util.promisify(setTimeout);
 
@@ -15,5 +16,23 @@ module.exports = {
 
   rimrafSync(filepath) {
     rmSync(filepath, { force: true, recursive: true });
+  },
+
+  getProperty(target, prop) {
+    const member = target[prop];
+    if (is.function(member)) {
+      return member.bind(target);
+    }
+    return member;
+  },
+  getEggOptions() {
+    const options = {};
+
+    if (process.env.EGG_BASE_DIR) {
+      options.baseDir = process.env.EGG_BASE_DIR;
+    } else {
+      options.baseDir = process.cwd();
+    }
+    return options;
   },
 };

--- a/test/parallel.test.js
+++ b/test/parallel.test.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const agentRegister = require('../lib/parallel/agent_register');
+
+describe('test/parallel.test.js', () => {
+  before(async () => {
+    await agentRegister.mochaGlobalSetup();
+    process.env.ENABLE_MOCHA_PARAELLEL = 'true';
+    process.env.AUTO_AGENT = 'true';
+    process.env.EGG_BASE_DIR = path.join(__dirname, './fixtures/apps/foo');
+  });
+
+  after(async () => {
+    await agentRegister.mochaGlobalTeardown();
+    delete process.env.ENABLE_MOCHA_PARAELLEL;
+    delete process.env.AUTO_AGENT;
+    delete process.env.EGG_BASE_DIR;
+  });
+
+  it('should work', async () => {
+    const { app } = require('../bootstrap');
+    await app.ready();
+    await app.httpRequest()
+      .get('/')
+      .expect(200)
+      .expect('foo');
+    await app.close();
+  });
+});


### PR DESCRIPTION
- use mochaGlobalSetup/mochaGlobalTeardown to setup agent in mocha master process.
- bootstrap app without agent to aviod port conflict.

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
