### PR TITLE
fix: don't close used mock agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ Object.assign(mock, mm, {
   restore() {
     cluster.restore();
     mockAgent.restore(app);
+    // return promise
     return mm.restore();
   },
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,8 @@ module.exports.default = mock;
 Object.assign(mock, mm, {
   restore() {
     cluster.restore();
-    mm.restore();
-    // return promise
-    return mockAgent.restore(app);
+    mockAgent.restore(app);
+    return mm.restore();
   },
 
   /**

--- a/lib/mock_agent.js
+++ b/lib/mock_agent.js
@@ -9,9 +9,9 @@ module.exports = {
     if (!_global) {
       _global = getGlobalDispatcher();
     }
-    if (!app[APP_HTTPCLIENT_AGENT] && typeof app?.httpclient?.getDispatcher === 'function') {
+    if (!app?.httpclient?.[APP_HTTPCLIENT_AGENT] && typeof app?.httpclient?.getDispatcher === 'function') {
       // save the raw dispatcher
-      app[APP_HTTPCLIENT_AGENT] = app.httpclient.getDispatcher();
+      app.httpclient[APP_HTTPCLIENT_AGENT] = app.httpclient.getDispatcher();
     }
     if (!_mockAgent) {
       _mockAgent = new MockAgent();
@@ -27,8 +27,8 @@ module.exports = {
     if (_global) {
       setGlobalDispatcher(_global);
     }
-    if (app?.[APP_HTTPCLIENT_AGENT]) {
-      app.httpclient.setDispatcher(app[APP_HTTPCLIENT_AGENT]);
+    if (app?.httpclient?.[APP_HTTPCLIENT_AGENT]) {
+      app.httpclient.setDispatcher(app.httpclient[APP_HTTPCLIENT_AGENT]);
     }
     _mockAgent = null;
   },

--- a/lib/mock_agent.js
+++ b/lib/mock_agent.js
@@ -8,12 +8,10 @@ module.exports = {
   getAgent(app) {
     if (!_global) {
       _global = getGlobalDispatcher();
-      if (typeof app?.httpclient?.getDispatcher === 'function') {
-        if (!app[APP_HTTPCLIENT_AGENT]) {
-          // save the raw dispatcher
-          app[APP_HTTPCLIENT_AGENT] = app.httpclient.getDispatcher();
-        }
-      }
+    }
+    if (!app[APP_HTTPCLIENT_AGENT] && typeof app?.httpclient?.getDispatcher === 'function') {
+      // save the raw dispatcher
+      app[APP_HTTPCLIENT_AGENT] = app.httpclient.getDispatcher();
     }
     if (!_mockAgent) {
       _mockAgent = new MockAgent();
@@ -24,16 +22,14 @@ module.exports = {
     }
     return _mockAgent;
   },
-  async restore(app) {
+  restore(app) {
     if (!_mockAgent) return;
     if (_global) {
       setGlobalDispatcher(_global);
-      if (app?.[APP_HTTPCLIENT_AGENT]) {
-        app.httpclient.setDispatcher(app[APP_HTTPCLIENT_AGENT]);
-      }
     }
-    const agent = _mockAgent;
+    if (app?.[APP_HTTPCLIENT_AGENT]) {
+      app.httpclient.setDispatcher(app[APP_HTTPCLIENT_AGENT]);
+    }
     _mockAgent = null;
-    await agent.close();
   },
 };


### PR DESCRIPTION
avoid ClientDestroyedError

```bash
ClientDestroyedError: The client is destroyed
      at Agent.dispatch (node_modules/undici/lib/dispatcher-base.js:172:15)
      at MockAgent.dispatch (node_modules/undici/lib/mock/mock-agent.js:65:25)
      at MockAgent.request (node_modules/undici/lib/api/api-request.js:169:10)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the control flow in the `restore()` method to enhance function execution order.
  - Streamlined logic in agent management for better clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->