### PR TITLE
fix: app.mockContext() should return egg context instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eggjs/mock",
-  "version": "6.0.6",
+  "version": "6.0.6-beta.3",
   "publishConfig": {
     "access": "public"
   },

--- a/src/app/extend/application.ts
+++ b/src/app/extend/application.ts
@@ -7,7 +7,8 @@ import { isAsyncFunction, isObject } from 'is-type-of';
 import { mock, restore } from 'mm';
 import type { HttpClient } from 'urllib';
 import { Transport, Logger, LoggerLevel, LoggerMeta } from 'egg-logger';
-import { EggCore, EggCoreOptions, Context } from '@eggjs/core';
+import { EggCore, type EggCoreOptions, type Context as EggCoreContext } from '@eggjs/core';
+import type { Context as EggContext } from 'egg';
 import { getMockAgent, restoreMockAgent } from '../../lib/mock_agent.js';
 import {
   createMockHttpClient, MockResultFunction,
@@ -39,7 +40,8 @@ export interface MockContextData {
   [key: string]: any;
 }
 
-export interface MockContext extends Context {
+// @ts-expect-error ignore type error
+export interface MockContext extends EggContext, EggCoreContext {
   service: any;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
	- Upgraded a core package to a beta release, paving the way for upcoming enhancements.
- Refactor
	- Refined internal structures for improved stability and long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->